### PR TITLE
bugfix: Fixed module throwing error when no config is provided to module

### DIFF
--- a/src/Module/Phiremock.php
+++ b/src/Module/Phiremock.php
@@ -154,7 +154,7 @@ class Phiremock extends CodeceptionModule
 
     private function setExpectationsPathConfiguration(): void
     {
-        $configuredPath = $this->config[self::EXPECTATIONS_PATH_CONFIG];
+        $configuredPath = $this->config[self::EXPECTATIONS_PATH_CONFIG] ?? null;
         if (empty($configuredPath)) {
             $defaultPath = codecept_data_dir(self::EXPECTATIONS_PATH);
             if (!is_dir($defaultPath)) {


### PR DESCRIPTION
# Description

Fixed `Undefined index: expectations_path` error that could appear when no configuration was provided to the Phiremock Module.   
This would cause the command to crash before the tests would even start

## Type of change
Bug fix

# How Has This Been Tested?

Tested with a project that uses the latest versions of the Codeception extension & module   
Can also be reproduced by removing the `expectationsPath: tests/_data/_unique_expectations` line from tests/acceptance.suite.yml
