### PR TITLE
feature: Add the ability to load expectations in subdirectories via annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Retrieves all the requests received by Phiremock server matching the one specifi
 
 ### @expectation Annotations
 
-Allows you to to set up an expectation via a json file 
+Allows you to to set up an expectation via a json file
 
 ```php
     /**
@@ -147,6 +147,18 @@ Allows you to to set up an expectation via a json file
 ```
 
 That will load by default the file at `tests/_data/phiremock-expectations/get_client_timeout.json`. The path where to place the expectations is configurable.
+
+You may use expectations placed in subdirectories
+
+```php
+    /**
+     * @expectation("edge_cases/get_client_timeout")
+     */
+    public function test(FunctionalTester $I)
+    {
+        ...
+    }
+```
 
 Multiple annotation formats are accepted
 

--- a/src/Util/ExpectationAnnotationParser.php
+++ b/src/Util/ExpectationAnnotationParser.php
@@ -43,7 +43,7 @@ class ExpectationAnnotationParser
     public function parseExpectation(string $expectationAnnotation): string
     {
         $matches = [];
-        $expectationRegex = '/\(?\"?(?<filePath>[a-zA-Z0-9_]+)(.json)?\"?\)?/';
+        $expectationRegex = '/\(?\"?(?<filePath>[a-zA-Z0-9_\\/]+)(.json)?\"?\)?/';
         preg_match($expectationRegex, $expectationAnnotation, $matches);
 
         if (empty($matches)) {

--- a/tests/_data/_unique_expectations/subdirectory/test_first_get.json
+++ b/tests/_data/_unique_expectations/subdirectory/test_first_get.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "GET",
+    "url": {
+      "isEqualTo" : "/expectation/subdirectory"
+    }
+  },
+  "response": {
+    "statusCode": 200,
+    "body": "response",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/tests/acceptance/BasicTestCest.php
+++ b/tests/acceptance/BasicTestCest.php
@@ -139,6 +139,19 @@ class BasicTestCest
         $requests = $I->grabRequestsMadeToRemoteService($requestBuilder);
         $I->assertCount(2, $requests);
     }
+    
+    /**
+     * @param AcceptanceTester $I
+     * @expectation("subdirectory/test_first_get")
+     */
+    public function testAnnotationInSubdirectoryIsLoaded(AcceptanceTester $I)
+    {
+        $conditionsBuilder = A::getRequest();
+        $requestBuilder = $conditionsBuilder->andMethod(Is::equalTo('GET'))->andUrl(Is::equalTo('/expectation/subdirectory'));
+        file_get_contents('http://localhost:18080/expectation/subdirectory');
+        $requests = $I->grabRequestsMadeToRemoteService($requestBuilder);
+        $I->assertCount(1, $requests);
+    }
 
     /**
      * @param AcceptanceTester $I


### PR DESCRIPTION
# Description

Small addition to the expectation annotation regex to allow expectation files in subdirectories to be loaded.

## Type of change
Feature

# How Has This Been Tested?

Addition of an automated tests  