### PR TITLE
Add compatibility with codeception/lib-asserts and codeception/module-asserts v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,13 @@
         "php" : "^7.2|^8.0",
         "mcustiel/phiremock-client": "^1.0",
         "codeception/codeception" : ">=2.2 <5.0",
-        "codeception/lib-asserts": "^1.1"
+        "codeception/lib-asserts": "^1.1|^2.0"
     },
     "require-dev" : {
         "mcustiel/phiremock-codeception-extension": "^2.0",
         "mcustiel/phiremock-server": "^1.0",
-        "codeception/module-asserts": "^1.1",
-        "guzzlehttp/guzzle" : "^7.0"
+        "guzzlehttp/guzzle" : "^7.0",
+        "codeception/module-asserts": "^1.1|^2.0"
     },
     "prefer-stable": true
 }

--- a/tests/unit/ExpectationParserTestCest.php
+++ b/tests/unit/ExpectationParserTestCest.php
@@ -21,7 +21,7 @@ class ExpectationParserTestCest
 
     public function expectationNotFoundThrowsParseError(UnitTester $I)
     {
-        $I->expectException(ParseException::class, function () {
+        $I->expectThrowable(ParseException::class, function () {
             $this->parser->parseExpectation("random.expectation");
         });
     }


### PR DESCRIPTION
- update composer.json package versions
- replace expectException to expectThrowable on ExpectationParserTestCest.php for compatibility with codeception/module-asserts v2